### PR TITLE
Check buffer existence on :LinediffReset

### DIFF
--- a/autoload/linediff/differ.vim
+++ b/autoload/linediff/differ.vim
@@ -109,7 +109,9 @@ function! linediff#differ#SetupDiffBuffer() dict
 endfunction
 
 function! linediff#differ#CloseDiffBuffer() dict
-  exe "bdelete ".self.diff_buffer
+  if bufexists(self.diff_buffer)
+    exe "bdelete ".self.diff_buffer
+  endif
 endfunction
 
 function! linediff#differ#SetupSigns() dict


### PR DESCRIPTION
This is needed to avoid error messages like this one:
<quote>E94: No matching buffer for -1</quote>

BTW thanks for the nice plugin.
