### PR TITLE
Add the option to indent the buffers before the Diff.

### DIFF
--- a/autoload/linediff/differ.vim
+++ b/autoload/linediff/differ.vim
@@ -17,6 +17,7 @@ function! linediff#differ#New(sign_name, sign_number)
         \ 'IsBlank':                   function('linediff#differ#IsBlank'),
         \ 'Reset':                     function('linediff#differ#Reset'),
         \ 'Lines':                     function('linediff#differ#Lines'),
+        \ 'Indent':                    function('linediff#differ#Indent'),
         \ 'CreateDiffBuffer':          function('linediff#differ#CreateDiffBuffer'),
         \ 'SetupDiffBuffer':           function('linediff#differ#SetupDiffBuffer'),
         \ 'CloseDiffBuffer':           function('linediff#differ#CloseDiffBuffer'),
@@ -81,6 +82,7 @@ function! linediff#differ#CreateDiffBuffer(edit_command) dict
   exe a:edit_command . " " . temp_file
   call append(0, lines)
   $delete _
+  call self.Indent()
   set nomodified
   normal! gg
 
@@ -88,6 +90,16 @@ function! linediff#differ#CreateDiffBuffer(edit_command) dict
   call self.SetupDiffBuffer()
 
   diffthis
+endfunction
+
+" Indents the current buffer content so that format can be ignored.
+function! linediff#differ#Indent() dict
+  if !exists("g:linediff_indent")
+    let g:linediff_indent = 0
+  endif
+  if g:linediff_indent == 1
+    normal! gg=G
+  endif
 endfunction
 
 " Sets up the temporary buffer's filetype and statusline.


### PR DESCRIPTION
Give the user a configuration option 'g:linediff_indent' to specify whether
to indent buffers before a Diff so as to limit differences associated to formatting.
