### PR TITLE
Restore value of 'cpoptions'

### DIFF
--- a/plugin/linediff.vim
+++ b/plugin/linediff.vim
@@ -53,3 +53,5 @@ function! s:PerformDiff()
   let s:differ_one.other_differ = s:differ_two
   let s:differ_two.other_differ = s:differ_one
 endfunction
+
+let &cpo = s:keepcpo


### PR DESCRIPTION
Hi Andrew,

I accidentally noticed that output of

``` vim
:set cpoptions
```

is

```
  cpoptions=aABceFs
```

while it should be

```
  cpoptions=aABceFs$
```

because I have this line in my `vimrc`:

``` vim
set cpoptions+=$
```

After running `grep` I saw that `linediff.vim` saves old value of the `'cpoptions'` at the beginning of the script, then resets `'cpoptions'` to defaults, but **doesn't** restore it at the end. This very small pull request fixes the issue.

Cheers,
xaizek
