### PR TITLE
Prevent :LinediffReset command from failing if plugin is uninitialized

### DIFF
--- a/plugin/linediff.vim
+++ b/plugin/linediff.vim
@@ -13,7 +13,7 @@ endif
 " Initialized lazily to avoid executing the autoload file before it's really
 " needed.
 function! s:Init()
-  if !exists('s:differ_one')
+  if !s:IsInitialized()
     let s:differ_one = linediff#differ#New('linediff_one', 1)
     let s:differ_two = linediff#differ#New('linediff_two', 2)
   endif
@@ -37,10 +37,15 @@ endfunction
 
 command! LinediffReset call s:LinediffReset()
 function! s:LinediffReset()
-  if exists('s:differ_one')
+  if s:IsInitialized()
     call s:differ_one.CloseAndReset()
     call s:differ_two.CloseAndReset()
   endif
+endfunction
+
+" Checks whether plugin is initialized.
+function! s:IsInitialized()
+  return exists('s:differ_one')
 endfunction
 
 " The closing logic is a bit roundabout, since changing a buffer in a


### PR DESCRIPTION
Don't try to reset anything if nothing is initialized.

The issue can be reproduced by running `:LinediffReset` command before `:Linediff` in Vim's session, in which case I got:

```
Error detected while processing function <SNR>41_LinediffReset:
line    1:
E121: Undefined variable: s:differ_one
line    2:
E121: Undefined variable: s:differ_two
```
