### PR TITLE
Ignore changes in temp buffers on :LinediffReset!

### DIFF
--- a/autoload/linediff/differ.vim
+++ b/autoload/linediff/differ.vim
@@ -68,8 +68,8 @@ endfunction
 
 " Closes the diff buffer and resets. The two actions are separate to avoid
 " problems with closing already closed buffers.
-function! linediff#differ#CloseAndReset() dict
-  call self.CloseDiffBuffer()
+function! linediff#differ#CloseAndReset(force) dict
+  call self.CloseDiffBuffer(a:force)
   call self.Reset()
 endfunction
 
@@ -145,9 +145,10 @@ function! linediff#differ#SetupDiffBuffer() dict
   endif
 endfunction
 
-function! linediff#differ#CloseDiffBuffer() dict
+function! linediff#differ#CloseDiffBuffer(force) dict
   if bufexists(self.diff_buffer)
-    exe "bdelete ".self.diff_buffer
+    let bang = a:force ? '!' : ''
+    exe "bdelete".bang." ".self.diff_buffer
   endif
 endfunction
 

--- a/doc/linediff.txt
+++ b/doc/linediff.txt
@@ -90,10 +90,12 @@ COMMANDS                                                   *linediff-commands*
 
 
                                               *:LinediffReset*
-:LinediffReset    Removes the signs denoting the diffed regions and deletes
+:LinediffReset[!] Removes the signs denoting the diffed regions and deletes
                   the temporary buffers, used for the diff. The original
                   buffers are untouched by this, which means that any updates
                   to them, performed by the diff process will remain.
+                  Specifying ! discards unsaved changes made in the temporary
+                  buffers.
 
 ==============================================================================
 SETTINGS                                                   *linediff-settings*

--- a/plugin/linediff.vim
+++ b/plugin/linediff.vim
@@ -43,16 +43,17 @@ function! s:Linediff(from, to)
 
     call s:PerformDiff()
   else
-    call s:LinediffReset()
+    call s:LinediffReset('!')
     call s:Linediff(a:from, a:to)
   endif
 endfunction
 
-command! LinediffReset call s:LinediffReset()
-function! s:LinediffReset()
+command! -bang LinediffReset call s:LinediffReset(<q-bang>)
+function! s:LinediffReset(bang)
   if s:IsInitialized()
-    call s:differ_one.CloseAndReset()
-    call s:differ_two.CloseAndReset()
+    let force = a:bang == '!'
+    call s:differ_one.CloseAndReset(force)
+    call s:differ_two.CloseAndReset(force)
   endif
 endfunction
 
@@ -70,11 +71,11 @@ endfunction
 function! s:PerformDiff()
   call s:differ_one.CreateDiffBuffer(g:linediff_first_buffer_command)
   autocmd BufUnload <buffer> silent call s:differ_one.Reset()
-  autocmd WinEnter <buffer> if s:differ_two.IsBlank() | silent call s:differ_one.CloseAndReset() | endif
+  autocmd WinEnter <buffer> if s:differ_two.IsBlank() | silent call s:differ_one.CloseAndReset(0) | endif
 
   call s:differ_two.CreateDiffBuffer(g:linediff_second_buffer_command)
   autocmd BufUnload <buffer> silent call s:differ_two.Reset()
-  autocmd WinEnter <buffer> if s:differ_one.IsBlank() | silent call s:differ_two.CloseAndReset() | endif
+  autocmd WinEnter <buffer> if s:differ_one.IsBlank() | silent call s:differ_two.CloseAndReset(0) | endif
 
   wincmd t " move to the first diff buffer
 


### PR DESCRIPTION
With this changes specifying `!` for the `:LinediffReset` discards unsaved changes made in the temporary buffers on closing them.
