### PR TITLE
Fix deleting more lines when folding is enabled

### DIFF
--- a/autoload/linediff/differ.vim
+++ b/autoload/linediff/differ.vim
@@ -176,6 +176,7 @@ function! linediff#differ#UpdateOriginalBuffer() dict
   set bufhidden=hide
   call linediff#util#SwitchBuffer(self.original_buffer)
   let saved_original_buffer_view = winsaveview()
+  exe "normal! zR"
   call cursor(self.from, 1)
   exe "normal! ".(self.to - self.from + 1)."dd"
   call append(self.from - 1, new_lines)


### PR DESCRIPTION
I use folding by default. When I try to save using this plugin, it deletes more lines than it should.
It was because my VIM regards a folding as single line when delete lines.
I found that opening all foldings before update original buffer fixes this issue.
