### PR TITLE
Fix User AutoCMD error

### DIFF
--- a/autoload/linediff/differ.vim
+++ b/autoload/linediff/differ.vim
@@ -109,7 +109,9 @@ function! linediff#differ#CreateDiffBuffer(edit_command) dict
 
   diffthis
 
-  doautocmd User LinediffBufferReady
+  if exists('#LinediffBufferReady')
+    doautocmd User LinediffBufferReady
+  endif
 endfunction
 
 " Indents the current buffer content so that format can be ignored.


### PR DESCRIPTION
Only call the autocmd if it is defined. This avaoids errors "No matching
autocmd" when running the plugin.