### PR TITLE
Correct the jump to new buffers

### DIFF
--- a/autoload/linediff.vim
+++ b/autoload/linediff.vim
@@ -35,7 +35,11 @@ function! s:PerformDiff()
   autocmd BufUnload <buffer> silent call s:differ_two.Reset()
   autocmd WinEnter <buffer> if s:differ_one.IsBlank() | silent call s:differ_two.CloseAndReset(0) | endif
 
-  wincmd t " move to the first diff buffer
+  let l:swb_old = &switchbuf
+  set switchbuf=useopen,usetab
+  " Move to the first diff buffer
+  execute 'sbuffer' s:differ_one.diff_buffer
+  let &switchbuf = l:swb_old
 
   let s:differ_one.other_differ = s:differ_two
   let s:differ_two.other_differ = s:differ_one


### PR DESCRIPTION
This fixes the case when you change the position where the new buffers
open.

In my case, I set the buffers to open in the current window below, using:

    let g:linediff_first_buffer_command  = 'rightbelow new'
    let g:linediff_second_buffer_command = 'rightbelow vertical new'
