### PR TITLE
added support for multiple diffs (up to 8)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,4 +24,6 @@ Executing the command `:LinediffReset` will delete the temporary buffers and rem
 
 Executing a new `:Linediff` will do the same as `:LinediffReset`, but will also initiate a new diff process.
 
+For more commands and different workflows, you should read the full documentation with [`:help linediff`](https://github.com/AndrewRadev/linediff.vim/blob/master/doc/linediff.txt)
+
 **Note that you shouldn't linediff two pieces of text that overlap**. Not that anything horribly bad will happen, it just won't work as you'd hope to. I don't feel like it's a very important use case, but if someone requests sensible behaviour in that case, I should be able to get it working.

--- a/autoload/linediff.vim
+++ b/autoload/linediff.vim
@@ -50,11 +50,14 @@ function! linediff#LinediffMerge()
     return
   endif
 
-  let [top_area, bottom_area] = areas
+  let [top_area, middle_area, bottom_area] = areas
   let [mfrom, mto] = [top_area[0] - 1, bottom_area[1] + 1]
 
-  call linediff#Linediff(top_area[0],    top_area[1],    {'is_merge': 1, 'merge_from': mfrom, 'merge_to': mto, 'label': top_area[2]})
-  call linediff#Linediff(bottom_area[0], bottom_area[1], {'is_merge': 1, 'merge_from': mfrom, 'merge_to': mto, 'label': bottom_area[2]})
+  call linediff#LinediffAdd(top_area[0],    top_area[1],    {'is_merge': 1, 'merge_from': mfrom, 'merge_to': mto, 'label': top_area[2]})
+  if middle_area[0] <= middle_area[1]
+    call linediff#LinediffAdd(middle_area[0], middle_area[1], {'is_merge': 1, 'merge_from': mfrom, 'merge_to': mto, 'label': middle_area[2]})
+  endif
+  call linediff#LinediffLast(bottom_area[0], bottom_area[1], {'is_merge': 1, 'merge_from': mfrom, 'merge_to': mto, 'label': bottom_area[2]})
 endfunction
 
 function! linediff#LinediffPick()
@@ -125,10 +128,16 @@ function! s:FindMergeMarkers()
   if search('^=======', 'cbW') <= 0
     return []
   endif
-  let middle_marker = line('.')
+  let other_marker = line('.')
+
+  let base_marker = other_marker
+  if search('^|||||||', 'cbW') > 0
+    let base_marker = line('.')
+  endif
 
   return [
-        \   [start_marker + 1, middle_marker - 1, start_label],
-        \   [middle_marker + 1, end_marker - 1, end_label],
+        \   [start_marker + 1, base_marker - 1, start_label],
+        \   [base_marker + 1, other_marker - 1, "common ancestor"],
+        \   [other_marker + 1, end_marker - 1, end_label],
         \ ]
 endfunction

--- a/autoload/linediff.vim
+++ b/autoload/linediff.vim
@@ -1,4 +1,5 @@
 let s:controller = linediff#controller#New()
+let g:controller = s:controller
 
 function! linediff#Linediff(from, to, options)
   if !s:controller.differs[1].IsBlank()
@@ -27,10 +28,7 @@ endfunction
 
 function! linediff#LinediffReset(bang)
   let force = a:bang == '!'
-  augroup LinediffAug
-  autocmd!
-  augroup END
-  let s:controller.CloseAndReset(force)
+  call s:controller.CloseAndReset(force)
 endfunction
 
 function! linediff#LinediffMerge()

--- a/autoload/linediff.vim
+++ b/autoload/linediff.vim
@@ -1,5 +1,4 @@
 let s:controller = linediff#controller#New()
-let g:controller = s:controller
 
 function! linediff#Linediff(from, to, options)
   if !s:controller.differs[1].IsBlank()

--- a/autoload/linediff.vim
+++ b/autoload/linediff.vim
@@ -34,6 +34,9 @@ endfunction
 
 function! linediff#LinediffReset(bang)
   let force = a:bang == '!'
+  augroup LinediffAug
+  autocmd!
+  augroup END
   for dfr in s:differ
     call dfr.CloseAndReset(force)
   endfor
@@ -48,7 +51,7 @@ function! linediff#LinediffMerge()
   endif
 
   let [top_area, bottom_area] = areas
-  let [mfrom, mto] = [top_area[0]-1, bottom_area[1]+1]
+  let [mfrom, mto] = [top_area[0] - 1, bottom_area[1] + 1]
 
   call linediff#Linediff(top_area[0],    top_area[1],    {'is_merge': 1, 'merge_from': mfrom, 'merge_to': mto, 'label': top_area[2]})
   call linediff#Linediff(bottom_area[0], bottom_area[1], {'is_merge': 1, 'merge_from': mfrom, 'merge_to': mto, 'label': bottom_area[2]})
@@ -81,6 +84,7 @@ function! s:PerformDiff()
     let &diffopt = g:linediff_diffopt
   endif
 
+  augroup LinediffAug
   call s:differ[0].CreateDiffBuffer(g:linediff_first_buffer_command)
   autocmd BufUnload <buffer> silent call linediff#LinediffReset('')
 
@@ -89,6 +93,7 @@ function! s:PerformDiff()
     call dfr.CreateDiffBuffer(g:linediff_further_buffer_command)
     autocmd BufUnload <buffer> silent call linediff#LinediffReset('')
   endfor
+  augroup END
 
   let l:swb_old = &switchbuf
   set switchbuf=useopen,usetab

--- a/autoload/linediff/controller.vim
+++ b/autoload/linediff/controller.vim
@@ -92,7 +92,16 @@ function! linediff#controller#PerformDiff() dict
 endfunction
 
 function! linediff#controller#StartDestroying() dict
-  let self.is_destroying = 1
+  " Only enter is_destroying mode if at least one differ is not blank
+  for differ in self.differs
+    if !differ.IsBlank()
+      let self.is_destroying = 1
+      return
+    endif
+  endfor
+
+  " If we're here, all differs are blank, reset is_destroying mode
+  let self.is_destroying = 0
 endfunction
 
 function! linediff#controller#Destroy(differ_index) dict

--- a/autoload/linediff/controller.vim
+++ b/autoload/linediff/controller.vim
@@ -54,8 +54,8 @@ function! linediff#controller#PerformDiff() dict
 
   " Use getbufvar instead of b:differ, since `%` != `<afile>` in some situations
   autocmd BufUnload <buffer>
-        \ call getbufvar(expand('<afile>'), 'differ').Reset() |
-        \ call getbufvar(expand('<afile>'), 'controller').StartDestroying()
+        \ call getbufvar(str2nr(expand('<abuf>')), 'differ').Reset() |
+        \ call getbufvar(str2nr(expand('<abuf>')), 'controller').StartDestroying()
   autocmd WinEnter <buffer>
         \ if b:controller.is_destroying |
         \   call b:controller.Destroy(0) |
@@ -72,8 +72,8 @@ function! linediff#controller#PerformDiff() dict
 
     " Use getbufvar instead of b:differ, since `%` != `<afile>` in some situations
     autocmd BufUnload <buffer>
-          \ call getbufvar(expand('<afile>'), 'differ').Reset() |
-          \ call getbufvar(expand('<afile>'), 'controller').StartDestroying()
+          \ call getbufvar(str2nr(expand('<abuf>')), 'differ').Reset() |
+          \ call getbufvar(str2nr(expand('<abuf>')), 'controller').StartDestroying()
     autocmd WinEnter <buffer>
           \ if b:controller.is_destroying |
           \   call b:controller.Destroy(b:differ.index) |

--- a/autoload/linediff/controller.vim
+++ b/autoload/linediff/controller.vim
@@ -1,0 +1,71 @@
+function! linediff#controller#New()
+  let controller = {
+        \ 'differs': [],
+        \
+        \ 'Add':           function('linediff#controller#Add'),
+        \ 'CloseAndReset': function('linediff#controller#CloseAndReset'),
+        \ 'PerformDiff':   function('linediff#controller#PerformDiff'),
+        \ }
+
+  for i in range(0,7)
+    let differ = linediff#differ#New('linediff'.string(i + 1), i + 1)
+    call add(controller.differs, differ)
+  endfor
+
+  return controller
+endfunction
+
+function! linediff#controller#Add(from, to, options) dict
+  for differ in self.differs
+    if differ.IsBlank()
+      call differ.Init(a:from, a:to, a:options)
+      return
+    endif
+  endfor
+
+  " if we're here, then all the differs are initialized
+  echoerr "It's not possible to add more than 8 blocks to Linediff!"
+endfunction
+
+function! linediff#controller#CloseAndReset(force) dict
+  for differ in self.differs
+    call differ.CloseAndReset(a:force)
+  endfor
+endfunction
+
+" The closing logic is a bit roundabout, since changing a buffer in a
+" BufUnload autocommand doesn't seem to work in some Vim versions.
+"
+" The process is: if one other differ was destroyed,
+" let the controller know about it, and it'll handle destroying all the rest
+" upon entering the other differs.
+"
+" TODO: not quite working right now for Vim 7.4.52
+"
+function! linediff#controller#PerformDiff() dict
+  if g:linediff_diffopt != 'builtin'
+    let g:linediff_original_diffopt = &diffopt
+    let &diffopt = g:linediff_diffopt
+  endif
+
+  augroup LinediffAug
+    call self.differs[0].CreateDiffBuffer(g:linediff_first_buffer_command)
+    autocmd BufUnload <buffer> silent call linediff#LinediffReset('')
+
+    for differ in self.differs[1:]
+      if differ.IsBlank() | break | endif
+      call differ.CreateDiffBuffer(g:linediff_further_buffer_command)
+      autocmd BufUnload <buffer> silent call linediff#LinediffReset('')
+    endfor
+  augroup END
+
+  let l:swb_old = &switchbuf
+  set switchbuf=useopen,usetab
+  " Move to the first diff buffer
+  execute 'sbuffer' self.differs[0].diff_buffer
+  let &switchbuf = l:swb_old
+
+  for differ in self.differs
+    let differ.other_differs = self.differs
+  endfor
+endfunction

--- a/autoload/linediff/differ.vim
+++ b/autoload/linediff/differ.vim
@@ -50,13 +50,11 @@ function! linediff#differ#Init(from, to, options) dict
   let self.from     = a:from
   let self.to       = a:to
 
-  if has_key(a:options, 'is_merge')
-    let self.is_merge = a:options.is_merge
-  endif
-
-  if has_key(a:options, 'label')
-    let self.label = a:options.label
-  endif
+  for k in keys(a:options)
+    if has_key(self, k)
+      let self[k] = a:options[k]
+    endif
+  endfor
 
   call self.SetupSigns()
 
@@ -187,13 +185,13 @@ function! linediff#differ#SetupDiffBuffer() dict
     exe "set filetype=" . self.filetype
     setlocal bufhidden=wipe
 
-    autocmd BufWrite <buffer> silent call b:differ.UpdateOriginalBuffer()
+    autocmd LinediffAug BufWrite <buffer> silent call b:differ.UpdateOriginalBuffer()
   else " g:linediff_buffer_type == 'scratch'
     silent exec 'keepalt file ' . escape(description, '[ ')
     exe "set filetype=" . self.filetype
     set nomodified
 
-    autocmd BufWriteCmd <buffer> silent call b:differ.UpdateOriginalBuffer()
+    autocmd LinediffAug BufWriteCmd <buffer> silent call b:differ.UpdateOriginalBuffer()
   endif
 endfunction
 
@@ -270,6 +268,9 @@ function! linediff#differ#UpdateOtherDiffer(delta, other) dict
     let a:other.to   = a:other.to   + a:delta
 
     call a:other.SetupSigns()
+  endif
+  if self.is_merge && a:other.is_merge
+    let a:other.merge_to = a:other.merge_to + a:delta
   endif
 endfunction
 

--- a/autoload/linediff/differ.vim
+++ b/autoload/linediff/differ.vim
@@ -12,8 +12,10 @@ function! linediff#differ#New(sign_name, sign_number)
         \ 'sign_number':        a:sign_number,
         \ 'sign_text':          a:sign_number.'-',
         \ 'is_blank':           1,
-        \ 'other_differ':       {},
+        \ 'other_differs':      {},
         \ 'is_merge':           0,
+        \ 'merge_from':         -1,
+        \ 'merge_to':           -1,
         \ 'label':              '',
         \
         \ 'Init':                      function('linediff#differ#Init'),
@@ -27,7 +29,8 @@ function! linediff#differ#New(sign_name, sign_number)
         \ 'SetupDiffBuffer':           function('linediff#differ#SetupDiffBuffer'),
         \ 'CloseDiffBuffer':           function('linediff#differ#CloseDiffBuffer'),
         \ 'UpdateOriginalBuffer':      function('linediff#differ#UpdateOriginalBuffer'),
-        \ 'PossiblyUpdateOtherDiffer': function('linediff#differ#PossiblyUpdateOtherDiffer'),
+        \ 'PossiblyUpdateOtherDiffers':function('linediff#differ#PossiblyUpdateOtherDiffers'),
+        \ 'UpdateOtherDiffer':         function('linediff#differ#UpdateOtherDiffer'),
         \ 'SetupSigns':                function('linediff#differ#SetupSigns'),
         \ 'ReplaceMerge':              function('linediff#differ#ReplaceMerge'),
         \ }
@@ -78,13 +81,15 @@ function! linediff#differ#Reset() dict
   let self.filetype           = ''
   let self.from               = -1
   let self.to                 = -1
-  let self.other_differ       = {}
+  let self.other_differs      = {}
 
   exe "sign unplace ".self.sign_number."1"
   exe "sign unplace ".self.sign_number."2"
 
   let self.is_blank = 1
   let self.is_merge = 0
+  let self.merge_from = -1
+  let self.merge_to = -1
   let self.label    = ''
 
   if exists('g:linediff_original_diffopt')
@@ -240,7 +245,7 @@ function! linediff#differ#UpdateOriginalBuffer() dict
   call self.SetupDiffBuffer()
   call self.SetupSigns()
 
-  call self.PossiblyUpdateOtherDiffer(new_line_count - line_count)
+  call self.PossiblyUpdateOtherDiffers(new_line_count - line_count)
   call winrestview(saved_diff_buffer_view)
 endfunction
 
@@ -249,16 +254,22 @@ endfunction
 " would result in a line shift.
 "
 " a:delta is the change in the number of lines.
-function! linediff#differ#PossiblyUpdateOtherDiffer(delta) dict
-  let other = self.other_differ
+function! linediff#differ#PossiblyUpdateOtherDiffers(delta) dict
+  if a:delta == 0
+    return
+  endif
+  for other in self.other_differs
+    call self.UpdateOtherDiffer(a:delta, other)
+  endfor
+endfunction
 
-  if self.original_buffer == other.original_buffer
-        \ && self.to <= other.from
-        \ && a:delta != 0
-    let other.from = other.from + a:delta
-    let other.to   = other.to   + a:delta
+function! linediff#differ#UpdateOtherDiffer(delta, other) dict
+  if self.original_buffer == a:other.original_buffer
+        \ && self.to <= a:other.from
+    let a:other.from = a:other.from + a:delta
+    let a:other.to   = a:other.to   + a:delta
 
-    call other.SetupSigns()
+    call a:other.SetupSigns()
   endif
 endfunction
 
@@ -274,8 +285,8 @@ function! linediff#differ#ReplaceMerge() dict
 
   try
     " Set the buffer range to the merge area in order to replace the whole thing
-    let self.from = min([self.from, self.other_differ.from]) - 1
-    let self.to   = max([self.to, self.other_differ.to]) + 1
+    let self.from = self.merge_from
+    let self.to   = self.merge_to
 
     call self.UpdateOriginalBuffer()
   finally

--- a/autoload/linediff/differ.vim
+++ b/autoload/linediff/differ.vim
@@ -5,6 +5,7 @@ function! linediff#differ#New(sign_name, sign_number)
         \ 'original_buffer':    -1,
         \ 'original_bufhidden': '',
         \ 'diff_buffer':        -1,
+        \ 'index':              -1,
         \ 'filetype':           '',
         \ 'from':               -1,
         \ 'to':                 -1,
@@ -12,7 +13,7 @@ function! linediff#differ#New(sign_name, sign_number)
         \ 'sign_number':        a:sign_number,
         \ 'sign_text':          a:sign_number.'-',
         \ 'is_blank':           1,
-        \ 'other_differs':      {},
+        \ 'other_differs':      [],
         \ 'is_merge':           0,
         \ 'merge_from':         -1,
         \ 'merge_to':           -1,
@@ -79,7 +80,7 @@ function! linediff#differ#Reset() dict
   let self.filetype           = ''
   let self.from               = -1
   let self.to                 = -1
-  let self.other_differs      = {}
+  let self.other_differs      = []
 
   exe "sign unplace ".self.sign_number."1"
   exe "sign unplace ".self.sign_number."2"
@@ -111,7 +112,7 @@ endfunction
 
 " Creates the buffer used for the diffing and connects it to this differ
 " object.
-function! linediff#differ#CreateDiffBuffer(edit_command) dict
+function! linediff#differ#CreateDiffBuffer(edit_command, index) dict
   let lines = self.Lines()
 
   if g:linediff_buffer_type == 'tempfile'
@@ -138,6 +139,7 @@ function! linediff#differ#CreateDiffBuffer(edit_command) dict
   endif
 
   let self.diff_buffer = bufnr('%')
+  let self.index = a:index
   call self.SetupDiffBuffer()
   call self.Indent()
 
@@ -185,13 +187,13 @@ function! linediff#differ#SetupDiffBuffer() dict
     exe "set filetype=" . self.filetype
     setlocal bufhidden=wipe
 
-    autocmd LinediffAug BufWrite <buffer> silent call b:differ.UpdateOriginalBuffer()
+    autocmd BufWrite <buffer> silent call b:differ.UpdateOriginalBuffer()
   else " g:linediff_buffer_type == 'scratch'
     silent exec 'keepalt file ' . escape(description, '[ ')
     exe "set filetype=" . self.filetype
     set nomodified
 
-    autocmd LinediffAug BufWriteCmd <buffer> silent call b:differ.UpdateOriginalBuffer()
+    autocmd BufWriteCmd <buffer> silent call b:differ.UpdateOriginalBuffer()
   endif
 endfunction
 

--- a/doc/linediff.txt
+++ b/doc/linediff.txt
@@ -139,26 +139,26 @@ display information on the proxy is by hacking the statusline, which may cause
 issues and can't work reliably on all statuslines.
 
                                             *g:linediff_first_buffer_command*
-                                            *g:linediff_second_buffer_command*
+                                            *g:linediff_further_buffer_command*
 >
     let g:linediff_first_buffer_command  = 'new'
-    let g:linediff_second_buffer_command = 'vertical new'
+    let g:linediff_further_buffer_command = 'vertical new'
 <
 
 Default values: "tabnew" and "rightbelow vertical new", respectively.
 
-These variables control what commands are used to open the two temporary
-buffers. By default, the first one will open a blank new tab, and the second
-one will split it vertically, from the right. This should ensure a pretty
-sensible setup.
+These variables control what commands are used to open the temporary
+buffers. By default, the first one will open a blank new tab, and the
+subsequent ones will split it vertically, from the right.
+This should ensure a pretty sensible setup.
 
 As an example, you can set them like so:
 >
     let g:linediff_first_buffer_command  = 'leftabove new'
-    let g:linediff_second_buffer_command = 'rightbelow vertical new'
+    let g:linediff_further_buffer_command = 'rightbelow vertical new'
 <
 With this, the buffers will be positioned in a split above the current buffer,
-the first one on the left, and the second one on the right.
+the first one on the left, and the subsequent ones on the right.
 
 You can control the positioning with judicious use of |:rightbelow| and
 |:leftabove|. If you omit these commands, the view will simply follow your

--- a/doc/linediff.txt
+++ b/doc/linediff.txt
@@ -37,7 +37,7 @@ The plugin provides a simple command, |:Linediff|, which is used to diff two
 separate blocks of text.
 
 A simple example:
-
+>
     def one
       two
     end
@@ -45,7 +45,7 @@ A simple example:
     def two
       three
     end
-
+<
 If we mark the first three lines, starting from "def one", in visual mode, and
 execute the |:Linediff| command, the signs "1-" will be placed at the start
 and at the end of the visual mode's range. Doing the same thing on the bottom
@@ -79,30 +79,121 @@ linediff with a `q`, try:
     autocmd User LinediffBufferReady nnoremap <buffer> q :LinediffReset<cr>
 <
 
+Diffing more than two areas ~
+
+If you'd like to diff more than two areas of code, you can use the
+|:LinediffAdd| command after the first |:Linediff| to mark more areas. You can
+then call |:LinediffShow| to open the diff:
+>
+    :1,2Linediff
+    :3,4LinediffAdd
+    :5,6LinediffAdd
+    :LinediffShow
+<
+This will diff the three specified areas. Alternatively, you can use the
+|:LinediffLast| command to add and show the differ. So, the above code is
+equivalent to:
+>
+    :1,2Linediff
+    :3,4LinediffAdd
+    :5,6LinediffLast
+<
+Note that there's a hard limit of 8 diffs set by Vim, so you can't diff more
+areas than that.
+
+Diffing merges ~
+
+If you have a merge conflict like this one:
+>
+    def one
+    <<<<<<< master
+      "first"
+    =======
+      "second"
+    >>>>>>> branch
+    end
+<
+You can easily start a diff between the two variants of the code by executing
+the |:LinediffMerge| command. You can use the diffed buffers the same way, or,
+you can use |:LinediffPick| to choose one buffer whose contents will replace
+the entire merge conflict. This also works with three-way diffs:
+>
+    def one
+    <<<<<<< master
+      "first"
+    |||||||
+      "second"
+    =======
+      "third"
+    >>>>>>> branch
+    end
+<
+The statuslines of the diff buffers will hold the label of the merge parent
+for convenience.
+
 ==============================================================================
 COMMANDS                                                   *linediff-commands*
 
-                                              *:Linediff*
-:Linediff         The main interface of the plugin. Needs to be executed on a
-                  range of lines, which will be marked with a sign. On the
-                  selection of the second such range, the command will open a
-                  tab with the two ranges in vertically split windows and
-                  perform a diff on them. Saving one of the two buffers will
-                  automatically update the original buffer the text was taken
-                  from.
+                                                                     *:Linediff*
+:[range]Linediff
 
-                  When executed for a third time, a new line diff is
-                  initiated, and the current process is reset, much like the
-                  effect of |LinediffReset| would be.
+The main interface of the plugin. Needs to be executed on a range of lines,
+which will be marked with a sign. On the selection of the second such range,
+the command will open a tab with the two ranges in vertically split windows
+and perform a diff on them. Saving one of the two buffers will automatically
+update the original buffer the text was taken from.
+
+When executed for a third time, a new line diff is initiated, and the current
+process is reset, much like the effect of |LinediffReset| would be.
 
 
-                                              *:LinediffReset*
-:LinediffReset[!] Removes the signs denoting the diffed regions and deletes
-                  the temporary buffers, used for the diff. The original
-                  buffers are untouched by this, which means that any updates
-                  to them, performed by the diff process will remain.
-                  Specifying ! discards unsaved changes made in the temporary
-                  buffers.
+                                                                *:LinediffReset*
+:LinediffReset[!]
+
+Removes the signs denoting the diffed regions and deletes the temporary
+buffers, used for the diff. The original buffers are untouched by this, which
+means that any updates to them, performed by the diff process will remain.
+Specifying ! discards unsaved changes made in the temporary buffers.
+
+
+                                                                  *:LinediffAdd*
+:[range]LinediffAdd
+
+Adds a buffer to be diffed later. This is an interface that allows diffing
+more than two areas. Should be followed by another "Add", or by "Show" or
+"Last" to finish the process of adding areas.
+
+
+                                                                 *:LinediffShow*
+:LinediffShow
+
+Shows the diff between all of the marked areas. This is useful if you've been
+adding areas with |:LinediffAdd| and you're ready to see their diff.
+
+
+                                                                 *:LinediffLast*
+:[range]LinediffLast
+
+Performs a combination of |:LinediffAdd| and |:LinediffShow|. Considers the
+marked area to be the last one added to the diff buffers and opens the diff.
+
+
+                                                                *:LinediffMerge*
+:LinediffMerge
+
+Looks for merge markers around the cursor, takes their contents and renders
+them in a diff. The diff buffers act like normal diff buffers, updating their
+parent buffer, but you can call |:LinediffPick| to pick one of them to replace
+the entire merge conflict area.
+
+
+                                                                 *:LinediffPick*
+:LinediffPick
+
+Only valid after a |:LinediffMerge|, in a diff buffer. Picks the diff buffer
+you're in as the "correct" one to replace the entire merge conflict area in
+the parent buffer.
+
 
 ==============================================================================
 SETTINGS                                                   *linediff-settings*

--- a/doc/linediff.txt
+++ b/doc/linediff.txt
@@ -285,10 +285,51 @@ order to keep the interface simple. They're located under
 Functions that are general-purpose utilities are placed in
 "autoload/linediff/util.vim".
 
-The two differ objects that are required for the two diff buffers are linked
-to each other out of necessity. If they originate from a single buffer,
-updating one would move the lines of the other, so that one would have to be
-updated as well. Apart from that, they have no interaction.
+All differ objects that are required for the diff buffers are linked to each
+other out of necessity. If they originate from a single buffer, updating one
+would move the lines of the other, so that one would have to be updated as
+well. There's a "controller" object that takes care of the high-level
+interaction between them.
+
+Closing ~
+
+Closing a diff buffer requires closing all diff buffers, because there's no
+longer any need in them existing. Turns out, this is a bit complicated in some
+Vim versions, because of weird connections between buffers, their local
+variables, and autocommands. On Vim 7.4.52, for instance, the plugin was able
+to segfault the editor by double-closing buffers. This is why closing is a bit
+of a complicated process.
+
+These are the different scenarios:
+
+- The user calls |:LinediffReset|: All diff buffers need to be closed. This
+  is the easy process -- just go through all buffers and close them one by
+  one, no dependencies.
+
+- The user closes a single diff buffer: A |BufUnload| autocommand is
+  triggered. That autocommand resets the differ (buffer id, line numbers,
+  etc), bringing it to an inactive state, but doesn't close it, since it's
+  already being closed. It sends a message to the Controller that the
+  destruction process has started.
+
+  From this point on, entering another window with a diff buffer destroys that
+  one as well (the |WinEnter| event is used). On every destruction, the
+  controller checks if all buffers have been cleared which would mean the
+  destruction process is over. This is hacky, but seems to a sensible way to
+  clear out all buffers, lazily, on older Vim versions.
+
+- The user closes all diff buffers with |:tabclose| or by switching to a new
+  tab and executing |:tabonly|: In this case, the |WinEnter| event never gets
+  called, but every closed diff buffer cleans itself up. It also starts the
+  "destroying" process in the Controller, but the Controller checks if there
+  are live differs, and if there aren't any left, removes its "destroying"
+  state, so that the next |WinEnter| wouldn't mess anything up.
+
+In short, the first unloaded buffer starts a destruction process, which means
+entering any diff buffer makes it self-destruct. If the buffers are all closed
+at once, that's fine, because the destruction process stops itself once there
+are no more live differs. Hacky, but seems to work.
+
 
 ==============================================================================
 ISSUES                                                       *linediff-issues*

--- a/plugin/linediff.vim
+++ b/plugin/linediff.vim
@@ -19,8 +19,8 @@ if !exists('g:linediff_first_buffer_command')
   let g:linediff_first_buffer_command = 'tabnew'
 endif
 
-if !exists('g:linediff_second_buffer_command')
-  let g:linediff_second_buffer_command = 'rightbelow vertical new'
+if !exists('g:linediff_further_buffer_command')
+  let g:linediff_further_buffer_command = 'rightbelow vertical new'
 endif
 
 if !exists('g:linediff_diffopt')
@@ -28,6 +28,9 @@ if !exists('g:linediff_diffopt')
 endif
 
 command! -range Linediff      call linediff#Linediff(<line1>, <line2>, {})
+command! -range LinediffAdd   call linediff#LinediffAdd(<line1>, <line2>, {})
+command! -range LinediffLast  call linediff#LinediffLast(<line1>, <line2>, {})
+command!        LinediffShow  call linediff#LinediffShow()
 command! -bang  LinediffReset call linediff#LinediffReset(<q-bang>)
 command!        LinediffMerge call linediff#LinediffMerge()
 command!        LinediffPick  call linediff#LinediffPick()

--- a/spec/plugin/closing_diff_buffers_spec.rb
+++ b/spec/plugin/closing_diff_buffers_spec.rb
@@ -45,10 +45,14 @@ describe "Basic" do
 
   specify "it's possible to close everything at once" do
     vim.normal 'A (changed)'
+    vim.write
     wincmd 'w'
     vim.normal 'A (changed)'
+    vim.write
 
+    # write the original buffer after it's been updated by the diff buffers
     vim.command 'wall'
+
     vim.command 'tabnew'
     vim.command 'tabonly'
 

--- a/spec/plugin/closing_diff_buffers_spec.rb
+++ b/spec/plugin/closing_diff_buffers_spec.rb
@@ -27,4 +27,34 @@ describe "Basic" do
       second (changed)
     EOF
   end
+
+  specify "original buffer updates upon closing one differ" do
+    vim.normal 'A (changed)'
+    vim.write
+    wincmd 'w'
+    vim.normal 'A (changed)'
+    vim.write
+
+    vim.command 'quit'
+
+    expect(buffer_contents).to eq <<~EOF
+      first (changed)
+      second (changed)
+    EOF
+  end
+
+  specify "it's possible to close everything at once" do
+    vim.normal 'A (changed)'
+    wincmd 'w'
+    vim.normal 'A (changed)'
+
+    vim.command 'wall'
+    vim.command 'tabnew'
+    vim.command 'tabonly'
+
+    expect_file_contents(<<~EOF)
+      first (changed)
+      second (changed)
+    EOF
+  end
 end

--- a/spec/plugin/merge_conflict_spec.rb
+++ b/spec/plugin/merge_conflict_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 describe "Merge conflicts" do
   let(:filename) { 'test.txt' }
 
-  before do
-    set_file_contents <<~EOF
+  describe "two-way" do
+    before do
+      set_file_contents <<~EOF
       def one
       <<<<<<< master
         "first"
@@ -12,38 +13,103 @@ describe "Merge conflicts" do
         "second"
       >>>>>>> branch
       end
-    EOF
+      EOF
 
-    vim.search 'first'
-    vim.command 'LinediffMerge'
-  end
+      vim.search 'first'
+      vim.command 'LinediffMerge'
+    end
 
-  specify "change and pick first buffer" do
-    vim.normal 'o  "change"'
-    vim.write
+    specify "change and pick first buffer" do
+      vim.normal 'o  "change"'
+      vim.write
 
-    vim.command 'LinediffPick'
+      vim.command 'LinediffPick'
 
-    expect(buffer_contents).to eq <<~EOF
+      expect(buffer_contents).to eq <<~EOF
       def one
         "first"
         "change"
       end
-    EOF
-  end
+      EOF
+    end
 
-  specify "change and pick second buffer" do
-    wincmd 'w'
-    vim.normal 'o  "change"'
-    vim.write
+    specify "change and pick second buffer" do
+      wincmd 'w'
+      vim.normal 'o  "change"'
+      vim.write
 
-    vim.command 'LinediffPick'
+      vim.command 'LinediffPick'
 
-    expect(buffer_contents).to eq <<~EOF
+      expect(buffer_contents).to eq <<~EOF
       def one
         "second"
         "change"
       end
-    EOF
+      EOF
+    end
+  end
+
+  describe "three-way" do
+    before do
+      set_file_contents <<~EOF
+      def one
+      <<<<<<< master
+        "first"
+      |||||||
+        "second"
+      =======
+        "third"
+      >>>>>>> branch
+      end
+      EOF
+
+      vim.search 'first'
+      vim.command 'LinediffMerge'
+    end
+
+    specify "change and pick first buffer" do
+      vim.normal 'o  "change"'
+      vim.write
+
+      vim.command 'LinediffPick'
+
+      expect(buffer_contents).to eq <<~EOF
+        def one
+          "first"
+          "change"
+        end
+      EOF
+    end
+
+    specify "change and pick second buffer" do
+      wincmd 'w'
+      vim.normal 'o  "change"'
+      vim.write
+
+      vim.command 'LinediffPick'
+
+      expect(buffer_contents).to eq <<~EOF
+        def one
+          "second"
+          "change"
+        end
+      EOF
+    end
+
+    specify "change and pick third buffer" do
+      wincmd 'w'
+      wincmd 'w'
+      vim.normal 'o  "change"'
+      vim.write
+
+      vim.command 'LinediffPick'
+
+      expect(buffer_contents).to eq <<~EOF
+        def one
+          "third"
+          "change"
+        end
+      EOF
+    end
   end
 end

--- a/spec/plugin/merge_conflict_spec.rb
+++ b/spec/plugin/merge_conflict_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "Multiple lines" do
+describe "Merge conflicts" do
   let(:filename) { 'test.txt' }
 
   before do

--- a/spec/plugin/multiple_diffs_spec.rb
+++ b/spec/plugin/multiple_diffs_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe "Multiple diffs" do
+  let(:filename) { 'test.txt' }
+
+  specify "with :LinediffAdd and :LinediffShow" do
+    set_file_contents <<~EOF
+      one
+      two
+      three
+    EOF
+
+    vim.command '1,1LinediffAdd'
+    vim.command '2,2LinediffAdd'
+    vim.command '3,3LinediffAdd'
+    vim.command 'LinediffShow'
+
+    expect(tabpage_buflist.length).to eq 3
+  end
+
+  specify "with :LinediffAdd and :LinediffLast" do
+    set_file_contents <<~EOF
+      one
+      two
+      three
+    EOF
+
+    vim.command '1,1LinediffAdd'
+    vim.command '2,2LinediffAdd'
+    vim.command '3,3LinediffLast'
+
+    expect(tabpage_buflist.length).to eq 3
+  end
+
+  specify "with :Linediff, :LinediffAdd and :LinediffLast" do
+    set_file_contents <<~EOF
+      one
+      two
+      three
+    EOF
+
+    vim.command '1,1Linediff'
+    vim.command '2,2LinediffAdd'
+    vim.command '3,3LinediffLast'
+
+    expect(tabpage_buflist.length).to eq 3
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ RSpec.configure do |config|
 
   config.after :each do
     vim.command 'wall'
+    vim.command 'tabnew'
     vim.command 'tabonly'
-    vim.command 'only'
   end
 end

--- a/spec/support/vim.rb
+++ b/spec/support/vim.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Support
   module Vim
     def set_file_contents(string)
@@ -5,8 +7,8 @@ module Support
       vim.edit!(filename)
     end
 
-    def assert_file_contents(string)
-      expect(IO.read(filename).strip).to eq(string)
+    def expect_file_contents(string)
+      expect(IO.read(filename).chomp).to eq(string.chomp)
     end
 
     def wincmd(command)
@@ -15,6 +17,10 @@ module Support
 
     def buffer_contents
       vim.echo(%<join(getbufline('%', 1, '$'), "\n")>) + "\n"
+    end
+
+    def tabpage_buflist
+      JSON.parse(vim.echo(%<tabpagebuflist()>))
     end
   end
 end


### PR DESCRIPTION
OK, that was quick :) 
I just couldn't resist to hack with this a bit, so here is my patch for my improvement proposal #26 

But it was done in a few hours, with only very basic vimscript knowledge, and without in-depth testing.
So maybe this PR is not really a PR but rather a TR (Try-Request).

I tried to be minimally-invasive, to change as little as possible.
Notably, the original UI was kept, so :Linediff will automatically start the diffing after 2 blocks have been selected.

Here is the rest of my commit message, it explains how to use the modification, and some other details:

- use LinediffAdd for each Block, LinediffLast for the last one
  OR use LinediffShow AFTER the last block
- max number of diff blocks = 8 is hardcoded, because it's the max number
  of diff buffers in the  newest vim, version 8
- older versions support only 4 diff buffers, no check is done for that
  they just throw an error if you try to diff more than 4 blocks
- LinediffMerge *should* work, not tested yet at all!!
- in general not very well tested yet, use with caution!

I would be very happy to receive feedback from anybody!