### PR TITLE
WIP: do not replace &stl in case of a function, but set bufvar

### DIFF
--- a/autoload/linediff/differ.vim
+++ b/autoload/linediff/differ.vim
@@ -180,12 +180,17 @@ function! linediff#differ#SetupDiffBuffer() dict
         \ label)
 
   if g:linediff_buffer_type == 'tempfile'
-    if &statusline =~ '%[fF]'
-      let statusline = substitute(&statusline, '%[fF]', escape(description, '\'), '')
+    if &statusline[0:1] ==# '%!'
+      " Statusline is a function, and might be replaced dynamically.
+      let b:linediff_description = description
     else
-      let statusline = description
+      if &statusline =~ '%[fF]'
+        let statusline = substitute(&statusline, '%[fF]', escape(description, '\'), '')
+      else
+        let statusline = description
+      endif
+      let &l:statusline = statusline
     endif
-    let &l:statusline = statusline
     exe "set filetype=" . self.filetype
     setlocal bufhidden=wipe
   else " g:linediff_buffer_type == 'scratch'


### PR DESCRIPTION
I am using a function for &stl, which also gets set on WinEnter etc.
For this, having `b:linediff_description` is good enough, and can be
used therein.

TODO:
- [ ] doc
- [ ] Q: should the buf var get set just always?